### PR TITLE
Upgrade dbus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,4 +8,4 @@ description = "Convenient macros to use the dbus crate"
 repository = "https://github.com/antoyo/dbus-macros-rs"
 
 [dependencies]
-dbus = "^0.5"
+dbus = "^0.6"


### PR DESCRIPTION
Is it ok to upgrade the underlying dbus crate? Couldn't use dbus `0.6` with `dbus-macros` as the underlying dependency is native